### PR TITLE
Problem: Publishing fails silently when client is reconnecting and

### DIFF
--- a/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
+++ b/aws-android-sdk-iot/src/main/java/com/amazonaws/mobileconnectors/iot/AWSIotMqttManager.java
@@ -1174,6 +1174,8 @@ public class AWSIotMqttManager {
                             AWSIotMqttMessageDeliveryCallback.MessageDeliveryStatus.Fail,
                             userData);
                 }
+            } else {
+            	throw new AmazonClientException("Client is reconnecting and publishing from offline queue is disabled.");
             }
         } else {
             throw new AmazonClientException("Client is disconnected or not yet connected.");


### PR DESCRIPTION
offline queues are disabled.
Fix: Allow application to handle republishing of failed messages OR
enable offline queues by throwing an exception under these conditions.